### PR TITLE
Add preemptible instances support

### DIFF
--- a/doc/source/command-objects/server.rst
+++ b/doc/source/command-objects/server.rst
@@ -72,6 +72,7 @@ Create a new server
         [--config-drive <value>|True ]
         [--min <count>]
         [--max <count>]
+        [--preemtible]
         [--wait]
         <server-name>
 
@@ -142,6 +143,10 @@ Create a new server
 .. option:: --max <count>
 
     Maximum number of servers to launch (default=1)
+
+.. option:: --preemptible
+
+    Indicates that the requested instance is preemptible
 
 .. option:: --wait
 

--- a/openstackclient/compute/v2/server.py
+++ b/openstackclient/compute/v2/server.py
@@ -379,6 +379,11 @@ class CreateServer(command.ShowOne):
             help=_('Maximum number of servers to launch (default=1)'),
         )
         parser.add_argument(
+            '--preemptible',
+            action='store_true',
+            help=_('Indicates that the requested instance is preemptible'),
+        )
+        parser.add_argument(
             '--wait',
             action='store_true',
             help=_('Wait for build to complete'),
@@ -528,7 +533,8 @@ class CreateServer(command.ShowOne):
             block_device_mapping=block_device_mapping,
             nics=nics,
             scheduler_hints=hints,
-            config_drive=config_drive)
+            config_drive=config_drive,
+            preemptible=parsed_args.preemptible)
 
         self.log.debug('boot_args: %s', boot_args)
         self.log.debug('boot_kwargs: %s', boot_kwargs)

--- a/openstackclient/tests/compute/v2/test_server.py
+++ b/openstackclient/tests/compute/v2/test_server.py
@@ -186,6 +186,56 @@ class TestServerCreate(TestServer):
             nics=[],
             scheduler_hints={},
             config_drive=None,
+            preemptible=False,
+        )
+        # ServerManager.create(name, image, flavor, **kwargs)
+        self.servers_mock.create.assert_called_with(
+            self.new_server.name,
+            self.image,
+            self.flavor,
+            **kwargs
+        )
+
+        self.assertEqual(self.columns, columns)
+        self.assertEqual(self.datalist(), data)
+
+    def test_server_create_preemptible(self):
+        arglist = [
+            '--image', 'image1',
+            '--flavor', 'flavor1',
+            '--preemptible',
+            self.new_server.name,
+        ]
+        verifylist = [
+            ('image', 'image1'),
+            ('flavor', 'flavor1'),
+            ('config_drive', False),
+            ('preemptible', True),
+            ('server_name', self.new_server.name),
+        ]
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+
+        # In base command class ShowOne in cliff, abstract method take_action()
+        # returns a two-part tuple with a tuple of column names and a tuple of
+        # data to be shown.
+        columns, data = self.cmd.take_action(parsed_args)
+
+        # Set expected values
+        kwargs = dict(
+            meta=None,
+            files={},
+            reservation_id=None,
+            min_count=1,
+            max_count=1,
+            security_groups=[],
+            userdata=None,
+            key_name=None,
+            availability_zone=None,
+            block_device_mapping={},
+            nics=[],
+            scheduler_hints={},
+            config_drive=None,
+            preemptible=True,
         )
         # ServerManager.create(name, image, flavor, **kwargs)
         self.servers_mock.create.assert_called_with(
@@ -273,6 +323,7 @@ class TestServerCreate(TestServer):
                    'port-id': 'port1_uuid'}],
             scheduler_hints={},
             config_drive=None,
+            preemptible=False,
         )
         # ServerManager.create(name, image, flavor, **kwargs)
         self.servers_mock.create.assert_called_with(
@@ -332,6 +383,7 @@ class TestServerCreate(TestServer):
             nics=[],
             scheduler_hints={},
             config_drive=None,
+            preemptible=False,
         )
         # ServerManager.create(name, image, flavor, **kwargs)
         self.servers_mock.create.assert_called_with(
@@ -385,6 +437,7 @@ class TestServerCreate(TestServer):
             nics=[],
             scheduler_hints={},
             config_drive=None,
+            preemptible=False,
         )
         # ServerManager.create(name, image, flavor, **kwargs)
         self.servers_mock.create.assert_called_with(


### PR DESCRIPTION
Launching a preemptible instance means passing an additional argument to
novaclient, in this case "--preemptible".

Change-Id: Ibb9b7ad6ec3e101f4560a16f3a9696fdead32e1f
